### PR TITLE
Add frontend versioned hosting

### DIFF
--- a/blogmatica/dev/outputs.tf
+++ b/blogmatica/dev/outputs.tf
@@ -32,3 +32,8 @@ output "app_hostname" {
   description = "Hostname of kubernetes app"
   value = module.subdomain.hostname
 }
+
+output "frontend_hostname" {
+  description = "Hostname of frontend app"
+  value = module.frontend.hostname
+}

--- a/blogmatica/dev/version.tf
+++ b/blogmatica/dev/version.tf
@@ -1,3 +1,4 @@
 locals {
-  image = "636934759355.dkr.ecr.us-east-1.amazonaws.com/nest-blogmatica:c506581bf1880f27c51ad494193579e03521267b"
+  backend_image = "636934759355.dkr.ecr.us-east-1.amazonaws.com/nest-blogmatica:0a8f3d4841b75eba36e38aa7a06dd40abc75f92c"
+  frontend_version = "v0.5.0"
 }

--- a/blogmatica/manifests/main.tf
+++ b/blogmatica/manifests/main.tf
@@ -6,13 +6,21 @@ resource "kubernetes_service" "service" {
   # BEGIN SERVICE CONFIG
   metadata {
     name = var.name
+    annotations = {
+      # Note that the backend talks over HTTP.
+      "service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "http"
+      "service.beta.kubernetes.io/aws-load-balancer-ssl-cert": var.acm_certificate_arn
+      # Only run SSL on the port named "https" below.
+      "service.beta.kubernetes.io/aws-load-balancer-ssl-ports": "https"
+    }
   }
   spec {
     selector = {
       app = var.name
     }
     port {
-      port = 80
+      name = "https"
+      port = 443
       target_port = 3000
     }
     type = "LoadBalancer"

--- a/blogmatica/manifests/variables.tf
+++ b/blogmatica/manifests/variables.tf
@@ -44,3 +44,8 @@ variable "creation_depends_on" {
   type = any
   default = null
 }
+
+variable "acm_certificate_arn" {
+  description = "ARN of ACM certificate to associate with LoadBalancer service"
+  type = string
+}

--- a/blogmatica/outputs.tf
+++ b/blogmatica/outputs.tf
@@ -32,3 +32,8 @@ output "dev_app_hostname" {
   description = "Hostname of kubernetes app"
   value = module.dev.app_hostname
 }
+
+output "dev_frontend_hostname" {
+  description = "Hostname of frontend app"
+  value = module.dev.frontend_hostname
+}

--- a/modules/acm_certificate/main.tf
+++ b/modules/acm_certificate/main.tf
@@ -1,0 +1,33 @@
+resource "aws_acm_certificate" "cert" {
+  domain_name       = var.domain_name
+  validation_method = "DNS"
+
+  tags = {
+    Environment = "test"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+data "aws_route53_zone" "zone" {
+  name         = var.public_hosted_zone_domain_name
+  private_zone = false
+}
+
+resource "aws_route53_record" "cert_validation" {
+  name    = aws_acm_certificate.cert.domain_validation_options[0].resource_record_name
+  type    = aws_acm_certificate.cert.domain_validation_options[0].resource_record_type
+  zone_id = data.aws_route53_zone.zone.id
+  records = [aws_acm_certificate.cert.domain_validation_options[0].resource_record_value]
+  ttl     = 60
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate_validation" "cert" {
+  certificate_arn         = aws_acm_certificate.cert.arn
+  validation_record_fqdns = [aws_route53_record.cert_validation.fqdn]
+}

--- a/modules/acm_certificate/outputs.tf
+++ b/modules/acm_certificate/outputs.tf
@@ -1,0 +1,4 @@
+output "acm_certificate_arn" {
+  description = "ARN of created ACM certificate"
+  value       = aws_acm_certificate.cert.arn
+}

--- a/modules/acm_certificate/variables.tf
+++ b/modules/acm_certificate/variables.tf
@@ -1,0 +1,10 @@
+variable "domain_name" {
+  description = "Domain name, such as test.bitmatica.com"
+  type = string
+}
+
+variable "public_hosted_zone_domain_name" {
+  description = "Domain name of existing public hosted zone"
+  type = string
+  default = "bitmatica.com."
+}

--- a/modules/s3_static_site/main.tf
+++ b/modules/s3_static_site/main.tf
@@ -1,0 +1,214 @@
+provider "aws" {
+  alias = "cloudfront"
+  region = "us-east-1"
+}
+
+resource "aws_acm_certificate" "cert" {
+  // CloudFront requires certs to be created in us-east-1
+  provider = aws.cloudfront
+  domain_name       = var.domain_name
+  validation_method = "DNS"
+
+  tags = {
+    Environment = "test"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+data "aws_route53_zone" "zone" {
+  // CloudFront requires certs to be created in us-east-1
+  provider = aws.cloudfront
+  name         = var.public_hosted_zone_domain_name
+  private_zone = false
+}
+
+resource "aws_route53_record" "cert_validation" {
+  // CloudFront requires certs to be created in us-east-1
+  provider = aws.cloudfront
+  name    = aws_acm_certificate.cert.domain_validation_options[0].resource_record_name
+  type    = aws_acm_certificate.cert.domain_validation_options[0].resource_record_type
+  zone_id = data.aws_route53_zone.zone.id
+  records = [aws_acm_certificate.cert.domain_validation_options[0].resource_record_value]
+  ttl     = 60
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate_validation" "cert" {
+  // CloudFront requires certs to be created in us-east-1
+  provider = aws.cloudfront
+  certificate_arn         = aws_acm_certificate.cert.arn
+  validation_record_fqdns = [aws_route53_record.cert_validation.fqdn]
+}
+
+resource "aws_s3_bucket" "bucket" {
+  bucket = var.name
+  # Bucket is not publicly accessible - CloudFront is given access via origin access identity
+  acl    = "private"
+
+  tags = {
+    Name = var.name
+  }
+}
+
+resource "aws_cloudfront_origin_access_identity" "origin_access_identity" {
+  comment = var.name
+}
+
+locals {
+  s3_origin_id = var.name
+}
+
+resource "aws_cloudfront_distribution" "s3_distribution" {
+  origin {
+    domain_name = aws_s3_bucket.bucket.bucket_regional_domain_name
+    origin_id   = local.s3_origin_id
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path
+    }
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = var.name
+  default_root_object = "${var.frontend_version}/index.html"
+  custom_error_response {
+    error_code = 404
+    response_page_path = "/${var.frontend_version}/index.html"
+    response_code = 200
+  }
+
+  logging_config {
+    include_cookies = false
+    bucket          = "${var.name}.s3.amazonaws.com"
+    prefix          = "cloudfront_logs"
+  }
+
+  aliases = [var.domain_name]
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+  # Cache behavior with precedence 0
+  # This is meant for immutable file names
+  ordered_cache_behavior {
+    path_pattern     = "/*/static/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+      headers      = ["Origin"]
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  # Cache behavior with precedence 1
+  ordered_cache_behavior {
+    path_pattern     = "/*/index.html"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 0
+    max_ttl                = 0
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  price_class = "PriceClass_200"
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "whitelist"
+      locations        = ["US", "CA", "GB", "DE"]
+    }
+  }
+
+  tags = {
+    Environment = var.name
+  }
+
+  viewer_certificate {
+    acm_certificate_arn = aws_acm_certificate.cert.arn
+    ssl_support_method = "sni-only"
+  }
+  depends_on = [aws_acm_certificate_validation.cert]
+}
+
+data "aws_iam_policy_document" "s3_policy" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.bucket.arn}/*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [
+        aws_cloudfront_origin_access_identity.origin_access_identity.iam_arn]
+    }
+  }
+
+  statement {
+    actions   = ["s3:ListBucket"]
+    resources = [
+      aws_s3_bucket.bucket.arn]
+
+    principals {
+      type        = "AWS"
+      identifiers = [
+        aws_cloudfront_origin_access_identity.origin_access_identity.iam_arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "s3_bucket_policy" {
+  bucket = aws_s3_bucket.bucket.id
+  policy = data.aws_iam_policy_document.s3_policy.json
+}
+
+resource "aws_route53_record" "www" {
+  zone_id = data.aws_route53_zone.zone.zone_id
+  name    = var.domain_name
+  type    = "CNAME"
+  ttl     = "300"
+  records = [aws_cloudfront_distribution.s3_distribution.domain_name]
+}

--- a/modules/s3_static_site/outputs.tf
+++ b/modules/s3_static_site/outputs.tf
@@ -1,0 +1,4 @@
+output "hostname" {
+  description = "Hostname that CloudFront points to"
+  value = var.domain_name
+}

--- a/modules/s3_static_site/variables.tf
+++ b/modules/s3_static_site/variables.tf
@@ -1,0 +1,20 @@
+variable "name" {
+  description = "Name of static site"
+  type = string
+}
+
+variable "domain_name" {
+  description = "Domain name, such as test.bitmatica.com"
+  type = string
+}
+
+variable "public_hosted_zone_domain_name" {
+  description = "Domain name of existing public hosted zone"
+  type = string
+  default = "bitmatica.com."
+}
+
+variable "frontend_version" {
+  description = "Version of frontend to serve from default CloudFront root.  This corresponds to bucket object key under main deploy bucket"
+  type = string
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -34,6 +34,11 @@ output "blogmatica_dev_app_hostname" {
   value = module.blogmatica.dev_app_hostname
 }
 
+output "blogmatica_dev_frontend_hostname" {
+  description = "Hostname of frontend app"
+  value = module.blogmatica.dev_frontend_hostname
+}
+
 output "region" {
   description = "AWS region"
   value = local.region


### PR DESCRIPTION
- Host frontend in s3 via CloudFront.
- Support HTTPS in viewer -> CloudFront and viewer -> k8s service.  Support Origin Access Identity for CloudFront -> s3 (s3 bucket is not publicly viewable).  Dynamically create certs for frontend/backend via DNS verification (no human intervention required).
- Manage frontend/backend versions in `blogmatica/dev/version.tf`

Notes:
- index.html has a max_ttl of 0, which should force both browsers/CloudFront to download index.html every time.  This file has absolute references to versioned (immutable) frontend assets which are aggressively cached.  I've also seen Cache-Control: no-cache as the preferred way to enforce this - didn't see a readily available cloudfront terraform option for this, though there is prob a way to set that if needed (via forwarded headers or something).