### PR TITLE
Secrets/permissions cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ crash.log
 # .tfvars files are managed as part of configuration and so should be included in
 # version control.
 #
-# example.tfvars
+secret.tfvars
 
 # Ignore override files as they are usually used to override resources locally and so
 # are not checked in

--- a/blogmatica/dev/variables.tf
+++ b/blogmatica/dev/variables.tf
@@ -7,3 +7,23 @@ variable "environment" {
   description = "Environment of the app, such as dev"
   type = string
 }
+
+variable "plaid_client_id" {
+  description = "Plaid Client ID"
+  type = string
+}
+
+variable "plaid_secret" {
+  description = "Plaid Secret"
+  type = string
+}
+
+variable "plaid_public_key" {
+  description = "Plaid Public Key"
+  type = string
+}
+
+variable "plaid_env" {
+  description = "Plaid Env"
+  type = string
+}

--- a/blogmatica/dev/versions.tf
+++ b/blogmatica/dev/versions.tf
@@ -1,4 +1,4 @@
 locals {
-  backend_image = "636934759355.dkr.ecr.us-east-1.amazonaws.com/nest-blogmatica:8dea1e9bafa20a546ff51d78d1bc0f25787b8111"
+  backend_image = "636934759355.dkr.ecr.us-east-1.amazonaws.com/nest-blogmatica:b2e44ab0ddd948e6349e2ddec1e0df5b81f444c5"
   frontend_version = "v0.5.0"
 }

--- a/blogmatica/main.tf
+++ b/blogmatica/main.tf
@@ -17,4 +17,8 @@ module "dev" {
   source = "./dev"
   environment = "dev"
   name = local.name
+  plaid_client_id = var.plaid_client_id
+  plaid_env = var.plaid_env
+  plaid_public_key = var.plaid_public_key
+  plaid_secret = var.plaid_secret
 }

--- a/blogmatica/manifests/locals.tf
+++ b/blogmatica/manifests/locals.tf
@@ -1,0 +1,4 @@
+locals {
+  k8s_service_account_namespace = "default"
+  k8s_service_account_name      = "blogmatica-dev"
+}

--- a/blogmatica/manifests/locals.tf
+++ b/blogmatica/manifests/locals.tf
@@ -1,4 +1,4 @@
 locals {
   k8s_service_account_namespace = "default"
-  k8s_service_account_name      = "blogmatica-dev"
+  k8s_service_account_name      = var.name
 }

--- a/blogmatica/manifests/variables.tf
+++ b/blogmatica/manifests/variables.tf
@@ -49,3 +49,28 @@ variable "acm_certificate_arn" {
   description = "ARN of ACM certificate to associate with LoadBalancer service"
   type = string
 }
+
+variable "plaid_client_id" {
+  description = "Plaid Client ID"
+  type = string
+}
+
+variable "plaid_secret" {
+  description = "Plaid Secret"
+  type = string
+}
+
+variable "plaid_public_key" {
+  description = "Plaid Public Key"
+  type = string
+}
+
+variable "plaid_env" {
+  description = "Plaid Env"
+  type = string
+}
+
+variable "cluster_oidc_issuer_url" {
+  description = "The URL on the EKS cluster OIDC Issuer"
+  type        = string
+}

--- a/blogmatica/variables.tf
+++ b/blogmatica/variables.tf
@@ -1,0 +1,19 @@
+variable "plaid_client_id" {
+  description = "Plaid Client ID"
+  type = string
+}
+
+variable "plaid_secret" {
+  description = "Plaid Secret"
+  type = string
+}
+
+variable "plaid_public_key" {
+  description = "Plaid Public Key"
+  type = string
+}
+
+variable "plaid_env" {
+  description = "Plaid Env"
+  type = string
+}

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,11 @@ locals {
 
 terraform {
   required_version = ">= 0.12.6"
+  backend "s3" {
+    bucket = "blogmatica-terraform"
+    key    = "blogmatica"
+    region = "us-west-2"
+  }
 }
 
 provider "aws" {
@@ -25,4 +30,8 @@ provider "null" {
 
 module "blogmatica" {
   source = "./blogmatica"
+  plaid_client_id = var.dev_plaid_client_id
+  plaid_env = var.dev_plaid_env
+  plaid_public_key = var.dev_plaid_public_key
+  plaid_secret = var.dev_plaid_secret
 }

--- a/modules/autoscaling_eks/main.tf
+++ b/modules/autoscaling_eks/main.tf
@@ -13,6 +13,8 @@ module "eks" {
 
   write_kubeconfig = false
 
+  enable_irsa  = true
+
   node_groups = {
     main = {
       # desired_capacity is just the initial value and updates are ignored by this module.

--- a/modules/autoscaling_eks/outputs.tf
+++ b/modules/autoscaling_eks/outputs.tf
@@ -41,3 +41,8 @@ output "cluster_ca_certificate" {
 output "cluster_token" {
   value = data.aws_eks_cluster_auth.cluster.token
 }
+
+output "cluster_oidc_issuer_url" {
+  description = "The URL on the EKS cluster OIDC Issuer"
+  value       = module.eks.cluster_oidc_issuer_url
+}

--- a/modules/autoscaling_eks/variables.tf
+++ b/modules/autoscaling_eks/variables.tf
@@ -22,10 +22,7 @@ variable "instance_type" {
 variable "map_accounts" {
   description = "Additional AWS account numbers to add to the aws-auth configmap."
   type        = list(string)
-  default = [
-    "777777777777",
-    "888888888888",
-  ]
+  default = []
 }
 
 variable "map_roles" {
@@ -35,13 +32,7 @@ variable "map_roles" {
     username = string
     groups   = list(string)
   }))
-  default = [
-    {
-      rolearn  = "arn:aws:iam::66666666666:role/role1"
-      username = "role1"
-      groups   = ["system:masters"]
-    },
-  ]
+  default = []
 }
 
 variable "map_users" {
@@ -51,16 +42,5 @@ variable "map_users" {
     username = string
     groups   = list(string)
   }))
-  default = [
-    {
-      userarn  = "arn:aws:iam::555555555555:user/user1"
-      username = "user1"
-      groups   = ["system:masters"]
-    },
-    {
-      userarn  = "arn:aws:iam::66666666666:user/user2"
-      username = "user2"
-      groups   = ["system:masters"]
-    },
-  ]
+  default = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,19 @@
+variable "dev_plaid_client_id" {
+  description = "Plaid Client ID"
+  type = string
+}
+
+variable "dev_plaid_secret" {
+  description = "Plaid Secret"
+  type = string
+}
+
+variable "dev_plaid_public_key" {
+  description = "Plaid Public Key"
+  type = string
+}
+
+variable "dev_plaid_env" {
+  description = "Plaid Env"
+  type = string
+}


### PR DESCRIPTION
- Use terraform remote state with s3 - encryption at rest and versioning are enabled per terraform recommendations: https://s3.console.aws.amazon.com/s3/object/blogmatica-terraform/blogmatica?region=us-west-2&tab=overview
- Generate db username/password with random_string/random_password resources instead of hardcoding
- Add plaid vars - they are currently in a `secret.tfvars` locally that is loaded during `apply` via `terraform apply -var-file="secret.tfvars"`.
- Use IAM Role for Service Accounts (IRSA) to give k8s deployment KMS access via a role attached to a service account.  This is preferred over the alternative of giving all worker (EC2) nodes a KMS role.  See https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/

Tested that I was able to complete a plaid token exchange (using KMS) on AWS/k8s

Notes
- While you can mark a terraform output as sensitive (which will mask it in `plan`/`apply` CLI output), you can't mark variables as sensitive.  This means that sensitive vars (such as plaid secrets) will still be displayed during terraform plan/apply and stored in terraform state.  With remote state in s3, at least these secrets are encrypted at rest (and transported with TLS).  But seeing secrets in CLI is still not ideal.  A better solution probably involves using a secret store like Vault/Consul and loading secrets within an app vs managing them in terraform.  Terraform docs say they plan to add better support for masking secrets but this is definitely a current drawback of managing secrets in terraform.
