### PR TITLE
Move secrets from env vars to k8s secrets

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_version = ">= 0.12.6"
   backend "s3" {
     bucket = "blogmatica-terraform"
-    key    = "blogmatica"
+    key    = "blogmatica/state"
     region = "us-west-2"
   }
 }


### PR DESCRIPTION
This prevents secrets from leaking to CLI output, as the `kubernetes_secret` resource hides secret values.